### PR TITLE
Updated the arXiv download links to use the correct API calls.

### DIFF
--- a/apd/config.py
+++ b/apd/config.py
@@ -36,7 +36,7 @@ HF_PAPERS_DATE_URL = "https://huggingface.co/papers?date={date}"
 HF_PAPERS_WEEK_URL = "https://huggingface.co/papers/week/{week}"  # e.g., /week/2026-W01
 
 # arXiv PDF download template
-ARXIV_PDF_URL = "https://arxiv.org/pdf/{paper_id}.pdf"
+ARXIV_PDF_URL = "https://export.arxiv.org/pdf/{paper_id}.pdf"
 
 # NotebookLM
 NOTEBOOKLM_URL = "https://notebooklm.google.com"
@@ -56,6 +56,9 @@ REQUEST_TIMEOUT = 60
 
 # Download chunk size
 DOWNLOAD_CHUNK_SIZE = 8192
+
+# Delay between downloads (seconds) to respect arXiv rate limits
+DOWNLOAD_DELAY_SECONDS = 3
 
 # Playwright timeouts (milliseconds)
 PLAYWRIGHT_TIMEOUT = 60000  # 60 seconds for general operations


### PR DESCRIPTION
Implemented a sleep(time)delay in the batch download function to respect the API rate limit. The current interval is 3 seconds between requests.

Do not use https://arxiv.org/pdf/{paper_id}.pdf, as it is subject to rate limiting and blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * PDF downloads now use the export.arxiv.org domain for improved access reliability and consistency
  * Automatic intervals between consecutive downloads have been added to enhance overall system stability during bulk paper retrieval operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->